### PR TITLE
Aggregated set of CSS and media size tweaks

### DIFF
--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -37,7 +37,7 @@
 /* Mobile (Portrait & Landscape)
 ================================================== */
 @media only screen and (max-width: 767px) {
-	#wrap { max-width: 100% }
+	#wrap { max-width: 100%; margin-bottom: 0; }
 	.col{ width: 100%; margin-left: 0; margin-bottom: 25px; }
 	#header-aside{ display: none; }
 	#logo { max-width: none; float: none; }

--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -1,4 +1,3 @@
-.container { max-width: 92%; }
 /* Mobile Menu
 ================================================== */
 	a#navigation-toggle { height: 45px; line-height: 45px; margin: 0 0 0 20px; cursor: pointer; color: #fff; font-weight: 600; position: relative; z-index: 9; text-decoration: none !important; font-size: 1.1em; }
@@ -38,7 +37,7 @@
 /* Mobile (Portrait & Landscape)
 ================================================== */
 @media only screen and (max-width: 767px) {
-	#wrap { padding: 25px; }
+	#wrap { max-width: 100% }
 	.col{ width: 100%; margin-left: 0; margin-bottom: 25px; }
 	#header-aside{ display: none; }
 	#logo { max-width: none; float: none; }

--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -44,8 +44,6 @@
 	.post-meta .meta-comments { display: none; }
 	.commentlist .children { margin: 0 }
 	.single-post-pagination { position: inherit; top: auto; margin: 10px 0 0; right: auto; }
-	.author-info .author-info-inner { padding-left: 0; }
-	.author-info .author-avatar { position: inherit; top: auto; left: auto; display: block; margin-bottom: 10px; }
 	.featured-slider-caption-excerpt { display: none; }
 	.featured-slider-caption-title { margin: 0; }
 	.flex-control-nav a { font-size: 0.8em; height: 20px; line-height: 20px; width: 20px; }
@@ -62,6 +60,9 @@
 @media only screen and (max-width: 479px) {
 	.featured-slider-caption { padding: 10px; }
 	.featured-slider-caption-title { margin: 0; font-size: 14px; }
+	.author-info .author-info-inner { padding-left: 0; }
+	.author-info .author-avatar { position: inherit; top: auto; left: auto; display: block; margin-bottom: 10px; }
+	.author-description { min-height: initial; }
 	.loop-entry.has-post-thumbnail .loop-entry-left,
 	.loop-entry.has-post-thumbnail .loop-entry-right { float: none; width: 100%; }
 	.loop-entry.has-post-thumbnail .loop-entry-left { margin-bottom: 10px; }

--- a/inc/image-sizes.php
+++ b/inc/image-sizes.php
@@ -9,8 +9,8 @@
 
 if ( ! function_exists( 'wpex_register_image_sizes' ) ) {
 	function wpex_register_image_sizes() {
-		add_image_size( 'wpex_page', 620, 9999 );
-		add_image_size( 'wpex_page_full', 920, 9999 );
+		add_image_size( 'wpex_page', 800, 9999 );
+		add_image_size( 'wpex_page_full', 9999, 9999 );
 		add_image_size( 'wpex_post', 800, 9999 );
 		add_image_size( 'wpex_home_slider', 800, 360, true );
 		add_image_size( 'wpex_entry', 400, 300, true );

--- a/inc/image-sizes.php
+++ b/inc/image-sizes.php
@@ -9,8 +9,8 @@
 
 if ( ! function_exists( 'wpex_register_image_sizes' ) ) {
 	function wpex_register_image_sizes() {
-		add_image_size( 'wpex_page', 9999, 9999 );
-		add_image_size( 'wpex_page_full', 9999, 9999 );
+		add_image_size( 'wpex_page', 620, 9999 );
+		add_image_size( 'wpex_page_full', 920, 9999 );
 		add_image_size( 'wpex_post', 800, 9999 );
 		add_image_size( 'wpex_home_slider', 800, 360, true );
 		add_image_size( 'wpex_entry', 400, 300, true );

--- a/page.php
+++ b/page.php
@@ -16,6 +16,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+// reduce content width for oEmbed
+$content_width = 620;
+
 get_header(); ?>
 
 	<div id="primary" class="content-area clr">

--- a/single.php
+++ b/single.php
@@ -12,6 +12,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+// reduce content width for oEmbed
+$content_width = 620;
+
 get_header(); ?>
 
 <div id="primary" class="content-area clr">

--- a/style.css
+++ b/style.css
@@ -26,7 +26,7 @@ html,body,div,span,applet,object,iframe,h1,h2,h3,h4,h5,h6,p,blockquote,pre,a,abb
 body { background: #efefef; color: #555; font: 14px/1.7em 'Lato', "Times New Roman", Times, serif; }
 body a { color: #02aace; text-decoration: none; }
 body a:hover { text-decoration: underline; }
-.container { margin: 0 auto; width: 980px; box-sizing: border-box; -moz-box-sizing: border-box; -webkit-box-sizing: border-box; }
+.container { margin: 0 auto; width: 980px; max-width: 89.677%; box-sizing: border-box; -moz-box-sizing: border-box; -webkit-box-sizing: border-box; }
 #wrap { background: #fff; padding: 30px 30px 0; margin: 40px auto; }
 .left-content { float: left; width: 67.392%; }
 .sidebar-container { float: right; width: 28.262%; }

--- a/style.css
+++ b/style.css
@@ -206,6 +206,7 @@ a:hover .loop-entry-video-overlay { text-shadow: 0 4px 4px rgba(0,0,0,0.5); }
 .author-info .author-info-inner { position: relative; padding-left: 100px; }
 .author-info .author-avatar { position: absolute; left: 0; top: 0; }
 .author-info .author-avatar img { border-radius: 2px; }
+.author-description { min-height: 75px; }
 
 /*related posts*/
 .related-posts { margin-bottom: 30px; }

--- a/style.css
+++ b/style.css
@@ -28,8 +28,8 @@ body a { color: #02aace; text-decoration: none; }
 body a:hover { text-decoration: underline; }
 .container { margin: 0 auto; width: 980px; box-sizing: border-box; -moz-box-sizing: border-box; -webkit-box-sizing: border-box; }
 #wrap { background: #fff; padding: 30px 30px 0; margin: 40px auto; }
-.left-content { float: left; width: 68%; }
-.sidebar-container { float: right; width: 28%; }
+.left-content { float: left; width: 67.392%; }
+.sidebar-container { float: right; width: 28.262%; }
 
 /* Commons
 --------------------------------------------------------------*/
@@ -45,9 +45,10 @@ address { letter-spacing: 1px; margin: 20px 0; }
 #page-featured-img img { display: block; width: 100%; }
 .double-divider { display: block; width: 100%; height: 3px; border-top: 1px solid #ccc; border-bottom: 1px solid #ccc; margin: 40px 0; }
 .heading { font-size: 1.2em; margin: 0 0 20px; font-weight: bold; border-bottom: 1px solid #ddd; color: #000; }
-.wpex-video-embed { position: relative; padding-bottom: 56.25%; padding-top: 25px; height: 0; }
+.wpex-video-embed, .embed-youtube { position: relative; padding-bottom: 56.25%; padding-top: 25px; height: 0; }
 .wpex-video-embed frame,
-.wpex-video-embed iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
+.wpex-video-embed iframe,
+.embed-youtube iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
 iframe, embed { max-width: 100%; }
 a.wpex-lightbox-gallery { display: block; }
 .page-thumbnail { margin-bottom: 30px; }


### PR DESCRIPTION
Basically fine-tuning the fluid wrapper width to get effective content widths of 620px and max 800px on different browser window sizes. Overwriting default $content_width for the non-full-width page/post templates. Adjusting media sizes accordingly and add a youtube oEmbed responsive resize rule (matching the one used for the Video post format header) ... plus a fix for the overlapping avatar when there is no author description.